### PR TITLE
Add animated sprite showcase to homepage

### DIFF
--- a/src/app/how-to-use-sprite-sheets/page.tsx
+++ b/src/app/how-to-use-sprite-sheets/page.tsx
@@ -4,48 +4,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useState, useEffect } from 'react'
-
-interface SpriteAnimationProps {
-  src: string
-  alt: string
-  size?: number
-  speed?: number
-  gridSize?: number
-}
-
-function SpriteAnimation({ src, alt, size = 64, speed = 150, gridSize = 3 }: SpriteAnimationProps) {
-  const [currentFrame, setCurrentFrame] = useState(0)
-  const totalFrames = gridSize * gridSize
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setCurrentFrame((prev) => (prev + 1) % totalFrames)
-    }, speed)
-
-    return () => clearInterval(interval)
-  }, [speed, totalFrames])
-
-  // Calculate frame position
-  const row = Math.floor(currentFrame / gridSize)
-  const col = currentFrame % gridSize
-  
-  return (
-    <div
-      className="border border-rich-black-400 rounded"
-      style={{
-        width: size,
-        height: size,
-        backgroundImage: `url(${src})`,
-        backgroundSize: `${size * gridSize}px ${size * gridSize}px`,
-        backgroundRepeat: 'no-repeat',
-        backgroundPosition: `-${col * size}px -${row * size}px`,
-        imageRendering: 'pixelated'
-      }}
-      title={alt}
-    />
-  )
-}
+import { useState } from 'react'
+import { SpriteAnimation } from '@/components/SpriteAnimation'
 
 export default function HowToUseSpriteSheets() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import { SpritePreview } from '@/components/SpritePreview'
 import { ProgressBar } from '@/components/ProgressBar'
 import { UserMenu } from '@/components/auth/UserMenu'
 import { generateSpriteSheet } from '@/lib/sprite-generator'
+import { SpriteAnimation } from '@/components/SpriteAnimation'
 
 const TEMPLATES = [
   { value: 'growing-star', label: 'Growing Star', description: 'A star that expands from small to large' },
@@ -175,15 +176,54 @@ export default function Home() {
 
       {/* Hero Section */}
       <div className="text-center py-16 px-4">
-     
+
         <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-mimi-pink-500 mb-6">
           Sprite Sheet Generator
         </h1>
         <p className="text-lg sm:text-xl text-citron-600 max-w-3xl mx-auto leading-relaxed px-4">
-          Create perfect sprite sheets with guaranteed character consistency. Our AI ensures 
-          your character maintains the same dimensions and appearance across all frames, 
+          Create perfect sprite sheets with guaranteed character consistency. Our AI ensures
+          your character maintains the same dimensions and appearance across all frames,
           making it easy to use for CSS animations and game development.
         </p>
+      </div>
+
+      {/* Sample Animated Sprites */}
+      <div className="bg-rich-black-200 py-8">
+        <div className="overflow-x-auto">
+          <div className="flex items-center gap-6 px-4 w-max">
+            <SpriteAnimation
+              src="/sample-sprites/blinking-blue-eye-2x2.png"
+              alt="Blinking blue eye animation"
+              size={96}
+              speed={200}
+              gridSize={2}
+            />
+            <SpriteAnimation
+              src="/sample-sprites/smiling-emoji.png"
+              alt="Smiling emoji animation"
+              size={96}
+              speed={220}
+            />
+            <SpriteAnimation
+              src="/sample-sprites/bouncing-ball.png"
+              alt="Bouncing ball animation"
+              size={96}
+              speed={130}
+            />
+            <SpriteAnimation
+              src="/sample-sprites/happy-bird.png"
+              alt="Happy bird animation"
+              size={96}
+              speed={110}
+            />
+            <SpriteAnimation
+              src="/sample-sprites/neon-star.png"
+              alt="Neon star animation"
+              size={96}
+              speed={160}
+            />
+          </div>
+        </div>
       </div>
 
       {/* Main Generator Section */}

--- a/src/components/SpriteAnimation.tsx
+++ b/src/components/SpriteAnimation.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+interface SpriteAnimationProps {
+  src: string
+  alt: string
+  size?: number
+  speed?: number
+  gridSize?: number
+}
+
+export function SpriteAnimation({ src, alt, size = 64, speed = 150, gridSize = 3 }: SpriteAnimationProps) {
+  const [currentFrame, setCurrentFrame] = useState(0)
+  const totalFrames = gridSize * gridSize
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentFrame((prev) => (prev + 1) % totalFrames)
+    }, speed)
+
+    return () => clearInterval(interval)
+  }, [speed, totalFrames])
+
+  const row = Math.floor(currentFrame / gridSize)
+  const col = currentFrame % gridSize
+
+  return (
+    <div
+      className="border border-rich-black-400 rounded"
+      style={{
+        width: size,
+        height: size,
+        backgroundImage: `url(${src})`,
+        backgroundSize: `${size * gridSize}px ${size * gridSize}px`,
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: `-${col * size}px -${row * size}px`,
+        imageRendering: 'pixelated'
+      }}
+      title={alt}
+    />
+  )
+}
+
+export default SpriteAnimation


### PR DESCRIPTION
## Summary
- Create reusable `SpriteAnimation` component for displaying animated sprite sheets
- Display horizontally scrollable gallery of sample animated sprites on the homepage
- Update tutorial page to use the shared `SpriteAnimation` component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: Failed to fetch fonts from Google)*

------
https://chatgpt.com/codex/tasks/task_e_68b4865d80e48323a70b4a4c304e0044