### PR TITLE
Add metadata to site route pages

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { Metadata } from 'next'
 import { useAuth } from '@/contexts/AuthContext'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -8,6 +9,31 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Progress } from '@/components/ui/progress'
 import { Crown, User, Calendar, Zap, History, CreditCard } from 'lucide-react'
 import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'Account - Sprite Sheet Generator',
+  description:
+    'Manage your Sprite Sheet Generator profile, subscription preferences, and sprite sheet generation history.',
+  openGraph: {
+    title: 'Account Dashboard - Sprite Sheet Generator',
+    description:
+      'Access your profile, subscription, usage stats, and project history for the AI-powered Sprite Sheet Generator.',
+    url: 'https://sprite-sheet-generator.com/account',
+    siteName: 'Sprite Sheet Generator',
+    images: ['https://sprite-sheet-generator.com/pink-sprinkles.gif'],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Account - Sprite Sheet Generator',
+    description:
+      'View your profile, manage subscription plans, and track sprite sheet generation usage.',
+    images: ['https://sprite-sheet-generator.com/pink-sprinkles.gif'],
+  },
+  alternates: {
+    canonical: 'https://sprite-sheet-generator.com/account',
+  },
+}
 
 export default function AccountPage() {
   const { user, loading } = useAuth()

--- a/src/app/how-to-use-sprite-sheets/page.tsx
+++ b/src/app/how-to-use-sprite-sheets/page.tsx
@@ -1,10 +1,36 @@
 'use client'
 
+import type { Metadata } from 'next'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useState, useEffect } from 'react'
+
+export const metadata: Metadata = {
+  title: 'How to Use Sprite Sheets - Sprite Sheet Generator',
+  description:
+    'Step-by-step guide to creating, animating, and implementing sprite sheets for games and web apps using the Sprite Sheet Generator.',
+  openGraph: {
+    title: 'How to Use Sprite Sheets',
+    description:
+      'Learn to create and animate sprite sheets for games, websites, and CSS animations with our AI-powered Sprite Sheet Generator guide.',
+    url: 'https://sprite-sheet-generator.com/how-to-use-sprite-sheets',
+    siteName: 'Sprite Sheet Generator',
+    images: ['https://sprite-sheet-generator.com/pink-sprinkles.gif'],
+    type: 'article',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'How to Use Sprite Sheets',
+    description:
+      'Follow this tutorial to build and animate sprite sheets with the AI Sprite Sheet Generator.',
+    images: ['https://sprite-sheet-generator.com/pink-sprinkles.gif'],
+  },
+  alternates: {
+    canonical: 'https://sprite-sheet-generator.com/how-to-use-sprite-sheets',
+  },
+}
 
 interface SpriteAnimationProps {
   src: string

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,11 +1,37 @@
 'use client'
 
+import type { Metadata } from 'next'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Check, X } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useState } from 'react'
+
+export const metadata: Metadata = {
+  title: 'Pricing - Sprite Sheet Generator',
+  description:
+    'Compare free, Pro, and Premium plans for the Sprite Sheet Generator and choose the right option for AI-powered sprite sheet creation.',
+  openGraph: {
+    title: 'Sprite Sheet Generator Pricing Plans',
+    description:
+      'Explore free, Pro, and Premium plans for the AI Sprite Sheet Generator and power up your animation workflow.',
+    url: 'https://sprite-sheet-generator.com/pricing',
+    siteName: 'Sprite Sheet Generator',
+    images: ['https://sprite-sheet-generator.com/pink-sprinkles.gif'],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Sprite Sheet Generator Pricing',
+    description:
+      'Discover free, Pro, and Premium plans for the AI-powered sprite sheet creator.',
+    images: ['https://sprite-sheet-generator.com/pink-sprinkles.gif'],
+  },
+  alternates: {
+    canonical: 'https://sprite-sheet-generator.com/pricing',
+  },
+}
 
 export default function PricingPage() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)


### PR DESCRIPTION
## Summary
- add SEO metadata for pricing page with open graph and twitter previews
- document how-to guide route with metadata and canonical link
- configure account dashboard route metadata including canonical URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b48732ecc083239e3fb596ddb0a28b