### PR TITLE
Add robots.txt and sitemap

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+Allow: /
+
+Disallow: /account
+Disallow: /api
+Disallow: /subscription
+
+Sitemap: https://sprite-sheet-generator.vercel.app/sitemap.xml

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,26 @@
+import { MetadataRoute } from 'next'
+
+const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://sprite-sheet-generator.vercel.app'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date()
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      lastModified,
+    },
+    {
+      url: `${baseUrl}/create-favicon`,
+      lastModified,
+    },
+    {
+      url: `${baseUrl}/how-to-use-sprite-sheets`,
+      lastModified,
+    },
+    {
+      url: `${baseUrl}/pricing`,
+      lastModified,
+    },
+  ]
+}


### PR DESCRIPTION
## Summary
- allow search engines to index public pages while blocking sensitive areas
- expose Next.js metadata sitemap listing primary routes

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b48737f2a48323ae9852a83ae9fe0c