### PR TITLE
feat: add canonical metadata and enforce https

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,22 @@ const nextConfig = {
       },
     ],
   },
+  async redirects() {
+    return [
+      {
+        source: '/:path*',
+        has: [
+          {
+            type: 'header',
+            key: 'x-forwarded-proto',
+            value: 'http',
+          },
+        ],
+        destination: 'https://sprite-sheet-generator.com/:path*',
+        permanent: true,
+      },
+    ]
+  },
 }
 
 module.exports = nextConfig

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,10 @@ const jetbrainsMono = JetBrains_Mono({
 })
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://sprite-sheet-generator.com'),
+  alternates: {
+    canonical: '/',
+  },
   title: 'Sprite Sheet Generator - AI-Powered Animation Creator',
   description: 'Generate sprite sheets for CSS animations using AI. Create pixel art, neon outlines, and more with our easy-to-use tool.',
   keywords: 'sprite sheet, animation, CSS, AI, generator, pixel art, game development',


### PR DESCRIPTION
## Summary
- set metadata base URL and site-wide canonical for SEO
- redirect HTTP traffic to HTTPS in Next.js config

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b48749ac648323bb177e26d8a023a8