### PR TITLE
feat: enhance metadata for social sharing

### DIFF
--- a/src/app/how-to-use-sprite-sheets/layout.tsx
+++ b/src/app/how-to-use-sprite-sheets/layout.tsx
@@ -9,11 +9,23 @@ export const metadata: Metadata = {
     description: 'Learn how to create smooth web animations using sprite sheets. Better than GIFs - faster loading, smaller files, and full CSS control.',
     type: 'article',
     url: 'https://sprite-sheet-generator.com/how-to-use-sprite-sheets',
+    siteName: 'Sprite Sheet Generator',
+    images: [
+      {
+        url: 'https://sprite-sheet-generator.com/og/how-to.png',
+        width: 1200,
+        height: 630,
+        alt: 'How to use sprite sheets preview image',
+      },
+    ],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'How to Use Sprite Sheets for Web Animation | Complete Guide',
     description: 'Learn how to create smooth web animations using sprite sheets. Better than GIFs - faster loading, smaller files, and full CSS control.',
+    site: '@SpriteSheetGen',
+    creator: '@SpriteSheetGen',
+    images: ['https://sprite-sheet-generator.com/og/how-to.png'],
   },
   alternates: {
     canonical: 'https://sprite-sheet-generator.com/how-to-use-sprite-sheets',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,22 @@ export const metadata: Metadata = {
     title: 'Sprite Sheet Generator',
     description: 'AI-powered sprite sheet creation for animations',
     type: 'website',
+    url: 'https://sprite-sheet-generator.com',
+    siteName: 'Sprite Sheet Generator',
+    images: [
+      {
+        url: 'https://sprite-sheet-generator.com/og/home.png',
+        width: 1200,
+        height: 630,
+        alt: 'Sprite Sheet Generator preview image',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    site: '@SpriteSheetGen',
+    creator: '@SpriteSheetGen',
+    images: ['https://sprite-sheet-generator.com/og/home.png'],
   },
   icons: {
     icon: [

--- a/src/app/pricing/layout.tsx
+++ b/src/app/pricing/layout.tsx
@@ -9,11 +9,23 @@ export const metadata: Metadata = {
     description: 'Simple, transparent pricing for AI-powered sprite sheet generation. Start free and upgrade as you grow.',
     type: 'website',
     url: 'https://sprite-sheet-generator.com/pricing',
+    siteName: 'Sprite Sheet Generator',
+    images: [
+      {
+        url: 'https://sprite-sheet-generator.com/og/pricing.png',
+        width: 1200,
+        height: 630,
+        alt: 'Pricing preview image',
+      },
+    ],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Pricing - Sprite Sheet Generator',
     description: 'Simple, transparent pricing for AI-powered sprite sheet generation. Start free and upgrade as you grow.',
+    site: '@SpriteSheetGen',
+    creator: '@SpriteSheetGen',
+    images: ['https://sprite-sheet-generator.com/og/pricing.png'],
   },
   alternates: {
     canonical: 'https://sprite-sheet-generator.com/pricing',


### PR DESCRIPTION
## Summary
- add site-wide Open Graph details and Twitter card metadata
- define dedicated Open Graph/Twitter images for key pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b4874dbba08323897c5954cfe0d3ea