### PR TITLE
Add structured data for pricing and tutorial pages

### DIFF
--- a/src/app/how-to-use-sprite-sheets/page.tsx
+++ b/src/app/how-to-use-sprite-sheets/page.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import Image from 'next/image'
 import Link from 'next/link'
+import Script from 'next/script'
 import { useState, useEffect } from 'react'
 
 interface SpriteAnimationProps {
@@ -50,10 +51,54 @@ function SpriteAnimation({ src, alt, size = 64, speed = 150, gridSize = 3 }: Spr
 export default function HowToUseSpriteSheets() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
 
+  const howToSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'HowTo',
+    name: 'How to Use Sprite Sheets',
+    description:
+      'Learn how to create and animate sprite sheets for your games and web projects.',
+    image: '/sample-sprites/smiling-emoji.png',
+    step: [
+      {
+        '@type': 'HowToStep',
+        name: 'Create Your Sprite Sheet',
+        text:
+          'Use our AI generator to make a sprite sheet with consistent characters. Choose your grid size based on how smooth you want the animation.',
+        image: '/sample-sprites/happy-bird.png'
+      },
+      {
+        '@type': 'HowToStep',
+        name: 'Add to Your Website',
+        text:
+          'Upload the sprite sheet image to your website and add it to your HTML with a simple image tag or CSS background.',
+        image: '/sample-sprites/bouncing-ball.png'
+      },
+      {
+        '@type': 'HowToStep',
+        name: 'Write the CSS Animation',
+        text:
+          'Copy our CSS code examples and adjust the timing and frame count to match your sprite sheet.',
+        image: '/sample-sprites/blinking-eye.png'
+      },
+      {
+        '@type': 'HowToStep',
+        name: 'Test and Enjoy',
+        text:
+          'Refresh your website and watch your character come to life! Adjust the speed if needed.',
+        image: '/sample-sprites/neon-star.png'
+      }
+    ]
+  }
+
   return (
     <div className="min-h-screen bg-rich-black">
+      <Script
+        id="howto-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(howToSchema) }}
+      />
       {/* Navigation */}
-      <nav className="relative flex justify-between items-center px-4 sm:px-6 py-4 border-b border-rich-black-300">
+        <nav className="relative flex justify-between items-center px-4 sm:px-6 py-4 border-b border-rich-black-300">
         <Link href="/" className="flex items-center gap-2">
           <Image 
             src="/pink-sprinkles.gif" 

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -5,12 +5,13 @@ import { Button } from '@/components/ui/button'
 import { Check, X } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
+import Script from 'next/script'
 import { useState } from 'react'
 
 export default function PricingPage() {
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+    const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
 
-  const plans = [
+    const plans = [
     {
       name: 'Free',
       price: '$0',
@@ -76,12 +77,34 @@ export default function PricingPage() {
       buttonVariant: 'default' as const,
       popular: false
     }
-  ]
+    ]
+
+  const productSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    itemListElement: plans.map((plan, index) => ({
+      '@type': 'Product',
+      name: `${plan.name} Plan`,
+      description: plan.description,
+      offers: {
+        '@type': 'Offer',
+        price: plan.price.replace('$', ''),
+        priceCurrency: 'USD',
+        availability: 'https://schema.org/InStock'
+      },
+      position: index + 1
+    }))
+  }
 
   return (
     <div className="min-h-screen bg-rich-black">
+      <Script
+        id="pricing-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(productSchema) }}
+      />
       {/* Navigation */}
-      <nav className="relative flex justify-between items-center px-4 sm:px-6 py-4 border-b border-rich-black-300">
+        <nav className="relative flex justify-between items-center px-4 sm:px-6 py-4 border-b border-rich-black-300">
         <Link href="/" className="flex items-center gap-2">
           <Image 
             src="/pink-sprinkles.gif" 


### PR DESCRIPTION
## Summary
- add JSON-LD Product/Offer schema to pricing page
- add HowTo schema with step images on tutorial page

## Testing
- `npm run lint`
- `npm run typecheck`
- `curl -s -D - https://searchconsole.googleapis.com/v1/urlTestingTools/richResults:run -H 'Content-Type: application/json' --data '{"html":"<script type=\"application/ld+json\">{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Product\\"}</script>"}'` *(403: Missing required API key)*

------
https://chatgpt.com/codex/tasks/task_e_68b4875564c083239536d85e3916ac9b