### PR TITLE
feat: add Open Graph images

### DIFF
--- a/src/app/how-to-use-sprite-sheets/layout.tsx
+++ b/src/app/how-to-use-sprite-sheets/layout.tsx
@@ -9,6 +9,13 @@ export const metadata: Metadata = {
     description: 'Learn how to create smooth web animations using sprite sheets. Better than GIFs - faster loading, smaller files, and full CSS control.',
     type: 'article',
     url: 'https://sprite-sheet-generator.com/how-to-use-sprite-sheets',
+    images: [
+      {
+        url: '/how-to-use-sprite-sheets/opengraph-image',
+        width: 1200,
+        height: 630,
+      },
+    ],
   },
   twitter: {
     card: 'summary_large_image',

--- a/src/app/how-to-use-sprite-sheets/opengraph-image.tsx
+++ b/src/app/how-to-use-sprite-sheets/opengraph-image.tsx
@@ -1,0 +1,31 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+export const revalidate = 60 * 60 * 24 // cache for one day
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#08070B',
+          color: '#FF77E0',
+          fontSize: 64,
+          fontWeight: 700,
+          textAlign: 'center',
+          padding: '0 50px',
+        }}
+      >
+        Sprite Sheet Guide
+      </div>
+    ),
+    size
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,13 @@ export const metadata: Metadata = {
     title: 'Sprite Sheet Generator',
     description: 'AI-powered sprite sheet creation for animations',
     type: 'website',
+    images: [
+      {
+        url: '/opengraph-image',
+        width: 1200,
+        height: 630,
+      },
+    ],
   },
   icons: {
     icon: [

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,29 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+export const revalidate = 60 * 60 * 24 // cache for one day
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#08070B',
+          color: '#FF77E0',
+          fontSize: 64,
+          fontWeight: 700,
+        }}
+      >
+        Sprite Sheet Generator
+      </div>
+    ),
+    size
+  )
+}

--- a/src/app/pricing/layout.tsx
+++ b/src/app/pricing/layout.tsx
@@ -9,6 +9,13 @@ export const metadata: Metadata = {
     description: 'Simple, transparent pricing for AI-powered sprite sheet generation. Start free and upgrade as you grow.',
     type: 'website',
     url: 'https://sprite-sheet-generator.com/pricing',
+    images: [
+      {
+        url: '/pricing/opengraph-image',
+        width: 1200,
+        height: 630,
+      },
+    ],
   },
   twitter: {
     card: 'summary_large_image',

--- a/src/app/pricing/opengraph-image.tsx
+++ b/src/app/pricing/opengraph-image.tsx
@@ -1,0 +1,29 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+export const revalidate = 60 * 60 * 24 // cache for one day
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#08070B',
+          color: '#FF77E0',
+          fontSize: 64,
+          fontWeight: 700,
+        }}
+      >
+        Pricing
+      </div>
+    ),
+    size
+  )
+}


### PR DESCRIPTION
## Summary
- generate Open Graph images via `ImageResponse`
- reference OG images in page metadata
- cache OG images for a day to improve performance

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: Failed to fetch font `JetBrains Mono`.)*


------
https://chatgpt.com/codex/tasks/task_e_68b4876164a08323a5b1c8ac2659f161