### PR TITLE
Refactor pricing and tutorial pages into server components

### DIFF
--- a/src/app/how-to-use-sprite-sheets/page.tsx
+++ b/src/app/how-to-use-sprite-sheets/page.tsx
@@ -1,114 +1,15 @@
-'use client'
-
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useState, useEffect } from 'react'
-
-interface SpriteAnimationProps {
-  src: string
-  alt: string
-  size?: number
-  speed?: number
-  gridSize?: number
-}
-
-function SpriteAnimation({ src, alt, size = 64, speed = 150, gridSize = 3 }: SpriteAnimationProps) {
-  const [currentFrame, setCurrentFrame] = useState(0)
-  const totalFrames = gridSize * gridSize
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setCurrentFrame((prev) => (prev + 1) % totalFrames)
-    }, speed)
-
-    return () => clearInterval(interval)
-  }, [speed, totalFrames])
-
-  // Calculate frame position
-  const row = Math.floor(currentFrame / gridSize)
-  const col = currentFrame % gridSize
-  
-  return (
-    <div
-      className="border border-rich-black-400 rounded"
-      style={{
-        width: size,
-        height: size,
-        backgroundImage: `url(${src})`,
-        backgroundSize: `${size * gridSize}px ${size * gridSize}px`,
-        backgroundRepeat: 'no-repeat',
-        backgroundPosition: `-${col * size}px -${row * size}px`,
-        imageRendering: 'pixelated'
-      }}
-      title={alt}
-    />
-  )
-}
+import Navigation from '@/components/Navigation'
+import SpriteAnimation from '@/components/SpriteAnimation'
 
 export default function HowToUseSpriteSheets() {
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
-
   return (
     <div className="min-h-screen bg-rich-black">
       {/* Navigation */}
-      <nav className="relative flex justify-between items-center px-4 sm:px-6 py-4 border-b border-rich-black-300">
-        <Link href="/" className="flex items-center gap-2">
-          <Image 
-            src="/pink-sprinkles.gif" 
-            alt="Pink sprinkles" 
-            width={32}
-            height={32}
-            className="w-8 h-8 object-contain"
-            unoptimized
-          />
-          <span className="text-lg sm:text-xl font-bold text-mimi-pink-500">Sprite Sheet Generator</span>
-        </Link>
-        
-        {/* Desktop Menu */}
-        <div className="hidden sm:flex items-center gap-6">
-          <Link href="/" className="text-purple-pizzazz hover:text-citron-500 transition-colors">
-            Home
-          </Link>
-          <a href="/pricing" className="text-purple-pizzazz hover:text-citron-500 transition-colors">
-            Pricing
-          </a>
-        </div>
-
-        {/* Mobile Menu Button */}
-        <button
-          className="sm:hidden flex flex-col gap-1 p-2"
-          onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-          aria-label="Toggle menu"
-        >
-          <div className={`w-5 h-0.5 bg-purple-pizzazz transition-transform ${isMobileMenuOpen ? 'rotate-45 translate-y-1.5' : ''}`} />
-          <div className={`w-5 h-0.5 bg-purple-pizzazz transition-opacity ${isMobileMenuOpen ? 'opacity-0' : ''}`} />
-          <div className={`w-5 h-0.5 bg-purple-pizzazz transition-transform ${isMobileMenuOpen ? '-rotate-45 -translate-y-1.5' : ''}`} />
-        </button>
-
-        {/* Mobile Menu Dropdown */}
-        {isMobileMenuOpen && (
-          <div className="absolute top-full left-0 right-0 bg-rich-black-200 border-b border-rich-black-300 sm:hidden z-50">
-            <div className="flex flex-col px-4 py-4 space-y-4">
-              <Link 
-                href="/" 
-                className="text-purple-pizzazz hover:text-citron-500 transition-colors"
-                onClick={() => setIsMobileMenuOpen(false)}
-              >
-                Home
-              </Link>
-              <a 
-                href="/pricing" 
-                className="text-purple-pizzazz hover:text-citron-500 transition-colors"
-                onClick={() => setIsMobileMenuOpen(false)}
-              >
-                Pricing
-              </a>
-            </div>
-          </div>
-        )}
-      </nav>
+      <Navigation active="how-to-use-sprite-sheets" />
 
       {/* Hero Section */}
       <div className="text-center py-12 sm:py-16 px-4">

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,15 +1,10 @@
-'use client'
-
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Check, X } from 'lucide-react'
-import Image from 'next/image'
 import Link from 'next/link'
-import { useState } from 'react'
+import Navigation from '@/components/Navigation'
 
 export default function PricingPage() {
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
-
   const plans = [
     {
       name: 'Free',
@@ -81,64 +76,7 @@ export default function PricingPage() {
   return (
     <div className="min-h-screen bg-rich-black">
       {/* Navigation */}
-      <nav className="relative flex justify-between items-center px-4 sm:px-6 py-4 border-b border-rich-black-300">
-        <Link href="/" className="flex items-center gap-2">
-          <Image 
-            src="/pink-sprinkles.gif" 
-            alt="Pink sprinkles" 
-            width={32}
-            height={32}
-            className="w-8 h-8 object-contain"
-            unoptimized
-          />
-          <span className="text-lg sm:text-xl font-bold text-mimi-pink-500">Sprite Sheet Generator</span>
-        </Link>
-        
-        {/* Desktop Menu */}
-        <div className="hidden sm:flex items-center gap-6">
-          <Link href="/" className="text-purple-pizzazz hover:text-citron-500 transition-colors">
-            Home
-          </Link>
-          <Link href="/how-to-use-sprite-sheets" className="text-purple-pizzazz hover:text-citron-500 transition-colors">
-            How to use sprite sheets
-          </Link>
-          <span className="text-citron-500">Pricing</span>
-        </div>
-
-        {/* Mobile Menu Button */}
-        <button
-          className="sm:hidden flex flex-col gap-1 p-2"
-          onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-          aria-label="Toggle menu"
-        >
-          <div className={`w-5 h-0.5 bg-purple-pizzazz transition-transform ${isMobileMenuOpen ? 'rotate-45 translate-y-1.5' : ''}`} />
-          <div className={`w-5 h-0.5 bg-purple-pizzazz transition-opacity ${isMobileMenuOpen ? 'opacity-0' : ''}`} />
-          <div className={`w-5 h-0.5 bg-purple-pizzazz transition-transform ${isMobileMenuOpen ? '-rotate-45 -translate-y-1.5' : ''}`} />
-        </button>
-
-        {/* Mobile Menu Dropdown */}
-        {isMobileMenuOpen && (
-          <div className="absolute top-full left-0 right-0 bg-rich-black-200 border-b border-rich-black-300 sm:hidden z-50">
-            <div className="flex flex-col px-4 py-4 space-y-4">
-              <Link 
-                href="/" 
-                className="text-purple-pizzazz hover:text-citron-500 transition-colors"
-                onClick={() => setIsMobileMenuOpen(false)}
-              >
-                Home
-              </Link>
-              <Link 
-                href="/how-to-use-sprite-sheets" 
-                className="text-purple-pizzazz hover:text-citron-500 transition-colors"
-                onClick={() => setIsMobileMenuOpen(false)}
-              >
-                How to use sprite sheets
-              </Link>
-              <span className="text-citron-500">Pricing</span>
-            </div>
-          </div>
-        )}
-      </nav>
+      <Navigation active="pricing" />
 
       {/* Hero Section */}
       <div className="text-center py-12 sm:py-16 px-4">

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { useState } from 'react'
+
+interface NavigationProps {
+  active?: 'home' | 'pricing' | 'how-to-use-sprite-sheets'
+}
+
+export function Navigation({ active }: NavigationProps) {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+
+  const links = [
+    { href: '/', label: 'Home', key: 'home' },
+    { href: '/how-to-use-sprite-sheets', label: 'How to use sprite sheets', key: 'how-to-use-sprite-sheets' },
+    { href: '/pricing', label: 'Pricing', key: 'pricing' }
+  ]
+
+  const renderLink = (link: {href: string; label: string; key: string}) => {
+    if (link.key === active) {
+      return (
+        <span key={link.key} className="text-citron-500">
+          {link.label}
+        </span>
+      )
+    }
+    return (
+      <Link
+        key={link.key}
+        href={link.href}
+        className="text-purple-pizzazz hover:text-citron-500 transition-colors"
+        onClick={() => setIsMobileMenuOpen(false)}
+      >
+        {link.label}
+      </Link>
+    )
+  }
+
+  return (
+    <nav className="relative flex justify-between items-center px-4 sm:px-6 py-4 border-b border-rich-black-300">
+      <Link href="/" className="flex items-center gap-2" onClick={() => setIsMobileMenuOpen(false)}>
+        <Image
+          src="/pink-sprinkles.gif"
+          alt="Pink sprinkles"
+          width={32}
+          height={32}
+          className="w-8 h-8 object-contain"
+          unoptimized
+        />
+        <span className="text-lg sm:text-xl font-bold text-mimi-pink-500">Sprite Sheet Generator</span>
+      </Link>
+
+      {/* Desktop Menu */}
+      <div className="hidden sm:flex items-center gap-6">
+        {links.map(renderLink)}
+      </div>
+
+      {/* Mobile Menu Button */}
+      <button
+        className="sm:hidden flex flex-col gap-1 p-2"
+        onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+        aria-label="Toggle menu"
+      >
+        <div
+          className={`w-5 h-0.5 bg-purple-pizzazz transition-transform ${
+            isMobileMenuOpen ? 'rotate-45 translate-y-1.5' : ''
+          }`}
+        />
+        <div
+          className={`w-5 h-0.5 bg-purple-pizzazz transition-opacity ${
+            isMobileMenuOpen ? 'opacity-0' : ''
+          }`}
+        />
+        <div
+          className={`w-5 h-0.5 bg-purple-pizzazz transition-transform ${
+            isMobileMenuOpen ? '-rotate-45 -translate-y-1.5' : ''
+          }`}
+        />
+      </button>
+
+      {/* Mobile Menu Dropdown */}
+      {isMobileMenuOpen && (
+        <div className="absolute top-full left-0 right-0 bg-rich-black-200 border-b border-rich-black-300 sm:hidden z-50">
+          <div className="flex flex-col px-4 py-4 space-y-4">
+            {links.map(renderLink)}
+          </div>
+        </div>
+      )}
+    </nav>
+  )
+}
+
+export default Navigation

--- a/src/components/SpriteAnimation.tsx
+++ b/src/components/SpriteAnimation.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export interface SpriteAnimationProps {
+  src: string
+  alt: string
+  size?: number
+  speed?: number
+  gridSize?: number
+}
+
+export function SpriteAnimation({ src, alt, size = 64, speed = 150, gridSize = 3 }: SpriteAnimationProps) {
+  const [currentFrame, setCurrentFrame] = useState(0)
+  const totalFrames = gridSize * gridSize
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentFrame((prev) => (prev + 1) % totalFrames)
+    }, speed)
+
+    return () => clearInterval(interval)
+  }, [speed, totalFrames])
+
+  const row = Math.floor(currentFrame / gridSize)
+  const col = currentFrame % gridSize
+
+  return (
+    <div
+      className="border border-rich-black-400 rounded"
+      style={{
+        width: size,
+        height: size,
+        backgroundImage: `url(${src})`,
+        backgroundSize: `${size * gridSize}px ${size * gridSize}px`,
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: `-${col * size}px -${row * size}px`,
+        imageRendering: 'pixelated'
+      }}
+      title={alt}
+    />
+  )
+}
+
+export default SpriteAnimation


### PR DESCRIPTION
## Summary
- split mobile navigation into reusable client component
- move sprite demo animation into its own client component
- convert pricing and how-to pages to server components that import the client pieces

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*
- `npx --yes lighthouse http://localhost:3000/pricing --quiet --chrome-flags="--headless" --only-categories=performance --output=json --output-path=stdout | jq '.categories.performance.score'` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b48766dda08323b68c4d9f9ab46377