### PR TITLE
Add free sprite sheet generator landing page with SEO metadata

### DIFF
--- a/src/app/free-sprite-sheet-generator/page.tsx
+++ b/src/app/free-sprite-sheet-generator/page.tsx
@@ -1,0 +1,134 @@
+import type { Metadata } from 'next'
+import Image from 'next/image'
+import Link from 'next/link'
+import Script from 'next/script'
+import { Button } from '@/components/ui/button'
+
+export const metadata: Metadata = {
+  title: 'Free Sprite Sheet Generator – Create Sprite Sheets Online with No Watermark',
+  description: 'Generate sprite sheets for games and animations free online. No watermark, no installs, completely free.',
+  keywords: ['free sprite sheet generator', 'online sprite sheet maker', 'no watermark sprite sheets'],
+  openGraph: {
+    title: 'Free Sprite Sheet Generator – Online & No Watermark',
+    description: 'Create sprite sheets online for free with zero watermarks. Ideal for game developers and animators.',
+    type: 'website',
+    images: [
+      {
+        url: '/sample-sprites/smiling-emoji.png',
+        width: 120,
+        height: 120,
+        alt: 'Sample sprite sheet without watermark'
+      }
+    ]
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Free Sprite Sheet Generator – Online & No Watermark',
+    description: 'Generate sprite sheets online for free with no watermark or downloads.',
+    images: ['/sample-sprites/smiling-emoji.png']
+  }
+}
+
+export default function FreeSpriteSheetGeneratorPage() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name: 'Free Sprite Sheet Generator',
+    description: 'Online sprite sheet maker. Create and download sprite sheets for free with no watermark.',
+    image: 'https://sprite-sheet-generator.com/sample-sprites/smiling-emoji.png',
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+      availability: 'https://schema.org/InStock',
+      url: 'https://sprite-sheet-generator.com/'
+    }
+  }
+
+  return (
+    <>
+      <Script
+        id="product-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <div className="min-h-screen bg-rich-black text-citron-600">
+        <div className="text-center py-12 px-4">
+          <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-mimi-pink-500 mb-4">
+            Free Sprite Sheet Generator
+          </h1>
+          <p className="text-lg sm:text-xl max-w-2xl mx-auto">
+            Craft high-quality sprite sheets online—absolutely free and with no watermark. Perfect for games, web animations, and creative experiments.
+          </p>
+          <div className="mt-8">
+            <Button asChild>
+              <Link href="/">Start Generating</Link>
+            </Button>
+          </div>
+        </div>
+
+        <div className="max-w-5xl mx-auto px-4 space-y-16 pb-16">
+          <section>
+            <h2 className="text-2xl sm:text-3xl text-purple-pizzazz text-center mb-6">Product Overview</h2>
+            <p className="max-w-3xl mx-auto leading-relaxed mb-4">
+              Our free sprite sheet generator runs entirely in your browser, giving you instant results without any downloads or subscriptions. Customize frame counts, canvas sizes, and art styles, then export crisp PNG sprite sheets ready for your project.
+            </p>
+            <ul className="list-disc space-y-2 max-w-3xl mx-auto text-left pl-6">
+              <li>Completely online—no software installation required</li>
+              <li>Zero cost and no hidden watermarks</li>
+              <li>Customizable templates and art styles</li>
+              <li>Instant PNG exports for games and websites</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl sm:text-3xl text-purple-pizzazz text-center mb-6">How to Use</h2>
+            <ol className="list-decimal space-y-2 max-w-3xl mx-auto text-left pl-6">
+              <li>Describe your animation concept or upload a reference image.</li>
+              <li>Select a style, frame count, and canvas size that fit your project.</li>
+              <li>Click <span className="font-semibold">Generate</span> to create and download your sprite sheet instantly.</li>
+            </ol>
+          </section>
+
+          <section>
+            <h2 className="text-2xl sm:text-3xl text-purple-pizzazz text-center mb-6">Screenshots &amp; Demos</h2>
+            <div className="grid sm:grid-cols-3 gap-6 justify-items-center">
+              <Image
+                src="/dancing-frog.gif"
+                alt="Animated frog demo"
+                width={160}
+                height={160}
+                className="border border-rich-black-400 rounded"
+              />
+              <Image
+                src="/sample-sprites/happy-bird.png"
+                alt="Happy bird sprite sheet example"
+                width={160}
+                height={160}
+                className="border border-rich-black-400 rounded"
+              />
+              <Image
+                src="/sample-sprites/neon-star.png"
+                alt="Neon star sprite sheet example"
+                width={160}
+                height={160}
+                className="border border-rich-black-400 rounded"
+              />
+            </div>
+          </section>
+
+          <section className="text-center">
+            <h2 className="text-2xl sm:text-3xl text-purple-pizzazz mb-4">Ready to Create?</h2>
+            <p className="mb-6">
+              Dive into the full-featured generator and build your own animations in seconds.
+            </p>
+            <Button asChild>
+              <Link href="/">Generate Your Sprite Sheet</Link>
+            </Button>
+          </section>
+        </div>
+      </div>
+    </>
+  )
+}
+

--- a/src/app/how-to-use-sprite-sheets/page.tsx
+++ b/src/app/how-to-use-sprite-sheets/page.tsx
@@ -71,6 +71,9 @@ export default function HowToUseSpriteSheets() {
           <Link href="/" className="text-purple-pizzazz hover:text-citron-500 transition-colors">
             Home
           </Link>
+          <Link href="/free-sprite-sheet-generator" className="text-purple-pizzazz hover:text-citron-500 transition-colors">
+            Free Sprite Sheet Generator
+          </Link>
           <a href="/pricing" className="text-purple-pizzazz hover:text-citron-500 transition-colors">
             Pricing
           </a>
@@ -91,15 +94,22 @@ export default function HowToUseSpriteSheets() {
         {isMobileMenuOpen && (
           <div className="absolute top-full left-0 right-0 bg-rich-black-200 border-b border-rich-black-300 sm:hidden z-50">
             <div className="flex flex-col px-4 py-4 space-y-4">
-              <Link 
-                href="/" 
+              <Link
+                href="/"
                 className="text-purple-pizzazz hover:text-citron-500 transition-colors"
                 onClick={() => setIsMobileMenuOpen(false)}
               >
                 Home
               </Link>
-              <a 
-                href="/pricing" 
+              <Link
+                href="/free-sprite-sheet-generator"
+                className="text-purple-pizzazz hover:text-citron-500 transition-colors"
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                Free Sprite Sheet Generator
+              </Link>
+              <a
+                href="/pricing"
                 className="text-purple-pizzazz hover:text-citron-500 transition-colors"
                 onClick={() => setIsMobileMenuOpen(false)}
               >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -130,6 +130,9 @@ export default function Home() {
           <a href="/how-to-use-sprite-sheets" className="text-purple-pizzazz hover:text-citron-500 transition-colors">
             How to use sprite sheets
           </a>
+          <a href="/free-sprite-sheet-generator" className="text-purple-pizzazz hover:text-citron-500 transition-colors">
+            Free Sprite Sheet Generator
+          </a>
           <a href="/pricing" className="text-purple-pizzazz hover:text-citron-500 transition-colors">
             Pricing
           </a>
@@ -151,15 +154,22 @@ export default function Home() {
         {isMobileMenuOpen && (
           <div className="absolute top-full left-0 right-0 bg-rich-black-200 border-b border-rich-black-300 sm:hidden z-50">
             <div className="flex flex-col px-4 py-4 space-y-4">
-              <a 
-                href="/how-to-use-sprite-sheets" 
+              <a
+                href="/how-to-use-sprite-sheets"
                 className="text-purple-pizzazz hover:text-citron-500 transition-colors"
                 onClick={() => setIsMobileMenuOpen(false)}
               >
                 How to use sprite sheets
               </a>
-              <a 
-                href="/pricing" 
+              <a
+                href="/free-sprite-sheet-generator"
+                className="text-purple-pizzazz hover:text-citron-500 transition-colors"
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                Free Sprite Sheet Generator
+              </a>
+              <a
+                href="/pricing"
                 className="text-purple-pizzazz hover:text-citron-500 transition-colors"
                 onClick={() => setIsMobileMenuOpen(false)}
               >


### PR DESCRIPTION
## Summary
- create `/free-sprite-sheet-generator` marketing page with product overview, feature list, usage steps, screenshots, and JSON-LD schema
- enrich landing page with keyword-heavy metadata for Open Graph and Twitter
- link new page from home and tutorial navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b48988fc4c8323bcf75b843afefacd